### PR TITLE
Update - Add checklist toolbar button

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,14 +64,6 @@
               'prose-checkbox',
               '&.prose :where(input[type="checkbox"])',
             )
-            addVariant(
-              'prose-checkbox-list',
-              '&.prose :where(ul:has(li > input[type="checkbox"]))',
-            )
-            addVariant(
-              'prose-checkbox-item',
-              '&.prose :where(ul:has(li > input[type="checkbox"]) li)',
-            )
           },
         ],
       }
@@ -80,7 +72,7 @@
   <body
     x-data="fakeCms"
     x-effect="refreshHtml"
-    class="dark:bg-[#111] bg-[#FAFAFA] relative"
+    class="dark:bg-[#111] bg-[#FAFAFA]"
   >
     <main>
       <div
@@ -91,7 +83,9 @@
           class="flex flex-col px-4 py-8 overflow-auto sm:px-6 lg:px-8 lg:py-12 lg:h-screen"
           :class="{ 'max-w-5xl mx-auto w-full': isFullscreen }"
         >
-          <div class="flex items-center justify-between">
+          <div
+            class="flex flex-col sm:flex-row sm:items-center sm:justify-between"
+          >
             <h1 class="text-lg font-bold dark:text-white">
               Tiny Markdown
               <span aria-hidden="true"> 🤏 </span>
@@ -421,29 +415,6 @@
                     <path d="M12 18V6" />
                     <path d="M17.5 10.5c1.7-1 3.5 0 3.5 1.5a2 2 0 0 1-2 2" />
                     <path d="M17 17.5c2 1.5 4 .3 4-1.5a2 2 0 0 0-2-2" />
-                  </svg>
-                </button>
-
-                <button
-                  :class="toolbarButtonClass"
-                  @click="modifyMarkdown('#### ')"
-                  aria-label="Heading four"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    class="size-4"
-                  >
-                    <path d="M12 18V6" />
-                    <path d="M17 10v3a1 1 0 0 0 1 1h3" />
-                    <path d="M21 10v8" />
-                    <path d="M4 12h8" />
-                    <path d="M4 18V6" />
                   </svg>
                 </button>
               </div>
@@ -789,7 +760,7 @@
           <article
             role="region"
             aria-label="Markdown preview"
-            class="prose max-w-none dark:prose-invert dark:prose-pre:bg-[#111] dark:checked:prose-checkbox:bg-[#111] prose-checkbox:text-black prose-checkbox:rounded prose-checkbox:size-5 prose-checkbox-item:flex prose-checkbox-item:gap-2 prose-checkbox-item:items-center dark:checked:prose-checkbox:bg-blue-600 dark:checked:prose-checkbox:border-blue-600 checked:prose-checkbox:bg-blue-500 checked:prose-checkbox:border-blue-500 prose-checkbox:border-[#EAEAEA] prose-checkbox:bg-white dark:prose-checkbox:border-[#333] dark:prose-checkbox:bg-[#111] prose-checkbox-list:list-none prose-checkbox-list:pl-0 prose-checkbox-item:pl-0"
+            class="prose max-w-none dark:prose-invert dark:prose-pre:bg-[#111] prose-checkbox:mr-1 prose-checkbox:-mt-1 dark:checked:prose-checkbox:bg-[#111] prose-checkbox:text-black prose-checkbox:rounded prose-checkbox:size-5 dark:checked:prose-checkbox:bg-blue-600 dark:checked:prose-checkbox:border-blue-600 checked:prose-checkbox:bg-blue-500 checked:prose-checkbox:border-blue-500 prose-checkbox:border-[#EAEAEA] prose-checkbox:bg-white dark:prose-checkbox:border-[#333] dark:prose-checkbox:bg-[#111]"
             x-html="contentHtml"
           ></article>
         </div>

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
           :class="{ 'max-w-5xl mx-auto w-full': isFullscreen }"
         >
           <div
-            class="flex flex-col sm:flex-row sm:items-center sm:justify-between"
+            class="flex flex-col sm:flex-row gap-4 sm:items-center sm:justify-between"
           >
             <h1 class="text-lg font-bold dark:text-white">
               Tiny Markdown
@@ -347,7 +347,7 @@
           </div>
 
           <div
-            class="flex justify-between gap-4 overflow-auto [&::-webkit-scrollbar]:hidden mt-8"
+            class="flex justify-between gap-4 overflow-auto [&::-webkit-scrollbar]:hidden mt-4"
           >
             <div class="flex gap-4">
               <div :class="toolbarGroupClass">

--- a/index.html
+++ b/index.html
@@ -58,24 +58,24 @@
     <script>
       tailwind.config = {
         darkMode: 'class',
+        plugins: [
+          function ({ addVariant }) {
+            addVariant(
+              'prose-checkbox',
+              '&.prose :where(input[type="checkbox"])',
+            )
+            addVariant(
+              'prose-checkbox-list',
+              '&.prose :where(ul:has(li > input[type="checkbox"]))',
+            )
+            addVariant(
+              'prose-checkbox-item',
+              '&.prose :where(ul:has(li > input[type="checkbox"]) li)',
+            )
+          },
+        ],
       }
     </script>
-
-    <style>
-      /* Hide list markers for task list items */
-      .prose ul:has(li > input[type='checkbox']) {
-        list-style: none;
-        padding-left: 0;
-      }
-
-      .prose ul:has(li > input[type='checkbox']) li {
-        padding-left: 0;
-      }
-
-      .prose input[type='checkbox'] {
-        margin-right: 0.5rem;
-      }
-    </style>
   </head>
   <body
     x-data="fakeCms"
@@ -589,7 +589,7 @@
                 <button
                   :class="toolbarButtonClass"
                   @click="modifyMarkdown('- [ ] ')"
-                  aria-label="Checklist"
+                  aria-label="Checkbox"
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -789,7 +789,7 @@
           <article
             role="region"
             aria-label="Markdown preview"
-            class="prose max-w-none dark:prose-invert dark:prose-pre:bg-[#111]"
+            class="prose max-w-none dark:prose-invert dark:prose-pre:bg-[#111] dark:checked:prose-checkbox:bg-[#111] prose-checkbox:text-black prose-checkbox:rounded prose-checkbox:size-5 prose-checkbox-item:flex prose-checkbox-item:gap-2 prose-checkbox-item:items-center dark:checked:prose-checkbox:bg-blue-600 dark:checked:prose-checkbox:border-blue-600 checked:prose-checkbox:bg-blue-500 checked:prose-checkbox:border-blue-500 prose-checkbox:border-[#EAEAEA] prose-checkbox:bg-white dark:prose-checkbox:border-[#333] dark:prose-checkbox:bg-[#111] prose-checkbox-list:list-none prose-checkbox-list:pl-0 prose-checkbox-item:pl-0"
             x-html="contentHtml"
           ></article>
         </div>

--- a/index.html
+++ b/index.html
@@ -60,6 +60,22 @@
         darkMode: 'class',
       }
     </script>
+
+    <style>
+      /* Hide list markers for task list items */
+      .prose ul:has(li > input[type='checkbox']) {
+        list-style: none;
+        padding-left: 0;
+      }
+
+      .prose ul:has(li > input[type='checkbox']) li {
+        padding-left: 0;
+      }
+
+      .prose input[type='checkbox'] {
+        margin-right: 0.5rem;
+      }
+    </style>
   </head>
   <body
     x-data="fakeCms"
@@ -567,6 +583,26 @@
                     <path d="M21 12H8" />
                     <path d="M21 19H8" />
                     <path d="M3 12v7" />
+                  </svg>
+                </button>
+
+                <button
+                  :class="toolbarButtonClass"
+                  @click="modifyMarkdown('- [ ] ')"
+                  aria-label="Checklist"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    class="size-4"
+                  >
+                    <rect width="18" height="18" x="3" y="3" rx="2" />
+                    <path d="m9 12 2 2 4-4" />
                   </svg>
                 </button>
               </div>


### PR DESCRIPTION
This pull request makes several improvements to the Markdown editor's UI and introduces enhanced support for checkboxes in both the toolbar and the Markdown preview. The changes focus on better layout responsiveness, improved styling for checkbox elements, and updating toolbar actions.

UI and Layout Improvements:

* Changed the header container to use a column layout on small screens and row layout on larger screens for better responsiveness.
* Adjusted the spacing in the toolbar area to improve visual hierarchy by changing the margin from `mt-8` to `mt-4`.
* Removed the `relative` class from the `<body>` element, simplifying global layout.

Toolbar Updates:

* Removed the "Heading Four" button from the toolbar to streamline available actions.
* Added a new "Checkbox" button to the toolbar, allowing users to quickly insert Markdown checkboxes.

Checkbox Styling Enhancements:

* Introduced a custom Tailwind variant plugin for styling checkboxes within `.prose` elements, and applied detailed styling rules to checkboxes in the Markdown preview for both light and dark modes. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R61-R75) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L756-R763)